### PR TITLE
Fixed spelling of pathes to paths

### DIFF
--- a/Plugins/Enlighter/Enlighter.swift
+++ b/Plugins/Enlighter/Enlighter.swift
@@ -171,7 +171,7 @@ struct Enlighter: BuildToolPlugin {
   {
     let groups = try EnlighterGroup.load(
       from: URL(fileURLWithPath: target.directory.string),
-      resourcesPathes:
+      resourcesPaths:
         collectResources(in: target, extensions: configuration.extensions),
       configuration: configuration
     )
@@ -335,7 +335,7 @@ extension Enlighter: XcodeBuildToolPlugin {
   {
     let groups = try EnlighterGroup.load(
       from: URL(fileURLWithPath: target.directory.string),
-      resourcesPathes:
+      resourcesPaths:
         collectResources(in: target, extensions: configuration.extensions),
       configuration: configuration
     )

--- a/Plugins/Enlighter/EnlighterGroup.swift
+++ b/Plugins/Enlighter/EnlighterGroup.swift
@@ -22,7 +22,7 @@ struct EnlighterGroup: CustomStringConvertible {
   // URLs to all input files for the group, e.g. `Contacts.db`,
   // `Contacts-01.sql`.
   var matches      : [ URL ]
-  // All `matches` that match the resource pathes passed in to the `load`
+  // All `matches` that match the resource paths passed in to the `load`
   // function (i.e. all inputs that will be copied as resource files into the
   // target).
   var resourceURLs = [ URL ]()
@@ -41,7 +41,7 @@ struct EnlighterGroup: CustomStringConvertible {
   }
   
   static func load(from    baseURL : URL,
-                   resourcesPathes : Set<String>,
+                   resourcesPaths : Set<String>,
                    configuration   : EnlighterTargetConfig)
                 throws -> [ EnlighterGroup ]
   {
@@ -69,7 +69,7 @@ struct EnlighterGroup: CustomStringConvertible {
         groups[stem] = EnlighterGroup(stem: stem, matches: [ url ])
       }
       
-      if resourcesPathes.contains(url.path) {
+      if resourcesPaths.contains(url.path) {
         groups[stem]?.resourceURLs.append(url)
       }
     }

--- a/Plugins/GenerateCodeForSQLite/EnlighterGroup.swift
+++ b/Plugins/GenerateCodeForSQLite/EnlighterGroup.swift
@@ -22,7 +22,7 @@ struct EnlighterGroup: CustomStringConvertible {
   // URLs to all input files for the group, e.g. `Contacts.db`,
   // `Contacts-01.sql`.
   var matches      : [ URL ]
-  // All `matches` that match the resource pathes passed in to the `load`
+  // All `matches` that match the resource paths passed in to the `load`
   // function (i.e. all inputs that will be copied as resource files into the
   // target).
   var resourceURLs = [ URL ]()
@@ -41,7 +41,7 @@ struct EnlighterGroup: CustomStringConvertible {
   }
 
   static func load(from    baseURL : URL,
-                   resourcesPathes : Set<String>,
+                   resourcesPaths : Set<String>,
                    configuration   : EnlighterTargetConfig)
                 throws -> [ EnlighterGroup ]
   {
@@ -69,7 +69,7 @@ struct EnlighterGroup: CustomStringConvertible {
         groups[stem] = EnlighterGroup(stem: stem, matches: [ url ])
       }
       
-      if resourcesPathes.contains(url.path) {
+      if resourcesPaths.contains(url.path) {
         groups[stem]?.resourceURLs.append(url)
       }
     }

--- a/Plugins/GenerateCodeForSQLite/GenerateCodeForSQLite.swift
+++ b/Plugins/GenerateCodeForSQLite/GenerateCodeForSQLite.swift
@@ -190,7 +190,7 @@ struct GenerateCodeForSQLite: CommandPlugin {
   {
     let groups = try EnlighterGroup.load(
       from: URL(fileURLWithPath: target.directory.string),
-      resourcesPathes:
+      resourcesPaths:
         collectResources(in: target, extensions: configuration.extensions),
       configuration: configuration
     )
@@ -354,7 +354,7 @@ extension GenerateCodeForSQLite: XcodeCommandPlugin {
   {
     let groups = try EnlighterGroup.load(
       from: URL(fileURLWithPath: target.directory.string),
-      resourcesPathes:
+      resourcesPaths:
         collectResources(in: target, extensions: configuration.extensions),
       configuration: configuration
     )

--- a/Sources/Lighter/Database/SQLDatabase.swift
+++ b/Sources/Lighter/Database/SQLDatabase.swift
@@ -3,7 +3,7 @@
 //  Copyright © 2022 ZeeZide GmbH.
 //
 
-// Later: Rework to use String pathes by default and only resort to URLs in
+// Later: Rework to use String paths by default and only resort to URLs in
 //        a canImport section.
 import struct Foundation.URL
 


### PR DESCRIPTION
The plural of path is paths. While reading the code I noticed the misspelling and it was an easy change to correct the spelling.
https://www.merriam-webster.com/dictionary/path