### PR TITLE
Add ability to configure pragmas

### DIFF
--- a/Plugins/Libraries/LighterGeneration/RecordGeneration/GenerateDatabaseStruct.swift
+++ b/Plugins/Libraries/LighterGeneration/RecordGeneration/GenerateDatabaseStruct.swift
@@ -306,7 +306,9 @@ extension EnlighterASTGenerator {
                     info: "A `URL` pointing to the database to be used."),
               .init(name: "readOnly",
                     info:
-                      "For protocol conformance, only allowed value: `true`.")
+                      "For protocol conformance, only allowed value: `true`."),
+              .init(name: "bootstrapSQL",
+                    info: "SQLite pragmas/SQL to apply to each connection."),
             ]
           ),
           inlinable: options.inlinable
@@ -318,11 +320,13 @@ extension EnlighterASTGenerator {
         .init(
           declaration: .makeInit(public: options.public,
             .init(keywordArg: "url", .name("URL")),
-            .init(keywordArg: "readOnly", .bool, .false)
+            .init(keywordArg: "readOnly", .bool, .false),
+            .init(keywordArg: "bootstrapSQL",
+                  .name("String? = nil")),
           ),
           statements: [
             .raw(
-              "self.\(api.connectionHandler) = .simplePool(url: url, readOnly: readOnly)"
+              "self.\(api.connectionHandler) = .simplePool(url: url, readOnly: readOnly, bootstrapSQL: bootstrapSQL)"
             )
           ],
           comment: .init(
@@ -348,7 +352,9 @@ extension EnlighterASTGenerator {
                     info: "A `URL` pointing to the database to be used."),
               .init(name: "readOnly",
                     info: "Whether the database should be opened "
-                        + "readonly (default: `false`).")
+                        + "readonly (default: `false`)."),
+              .init(name: "bootstrapSQL",
+                    info: "SQLite pragmas/SQL to apply to each connection."),
             ]
           ),
           inlinable: options.inlinable

--- a/Sources/Lighter/ConnectionHandlers/SQLConnectionHandler.swift
+++ b/Sources/Lighter/ConnectionHandlers/SQLConnectionHandler.swift
@@ -22,22 +22,27 @@ open class SQLConnectionHandler: @unchecked Sendable {
    * a lot of async calls.
    */
   public static func reopen(url: URL, readOnly: Bool = false,
-                            writeTimeout: TimeInterval = 10.0)
-                     -> SQLConnectionHandler
+                            writeTimeout: TimeInterval = 10.0,
+                            bootstrapSQL: String? = nil) -> SQLConnectionHandler
   {
-    SQLConnectionHandler(url: url, readOnly: readOnly,
-                         writeTimeout: writeTimeout)
+    SQLConnectionHandler(url: url, 
+                         readOnly: readOnly,
+                         writeTimeout: writeTimeout, 
+                         bootstrapSQL: bootstrapSQL)
   }
   
   public static func simplePool(url: URL, readOnly: Bool,
                                 maxAge: TimeInterval = 3.0,
                                 maximumPoolSizePerConfiguration: Int = 8,
-                                writeTimeout: TimeInterval = 10.0)
-                     -> SimplePool
+                                writeTimeout: TimeInterval = 10.0,
+                                bootstrapSQL: String? = nil) -> SimplePool
   {
-    SimplePool(url: url, readOnly: readOnly, maxAge: maxAge,
+    SimplePool(url: url, 
+               readOnly: readOnly, 
+               maxAge: maxAge,
                maximumPoolSizePerConfiguration: maximumPoolSizePerConfiguration,
-               writeTimeout: writeTimeout)
+               writeTimeout: writeTimeout, 
+               bootstrapSQL: bootstrapSQL)
   }
   
   /**
@@ -72,14 +77,18 @@ open class SQLConnectionHandler: @unchecked Sendable {
   public let url          : URL
   public let readOnly     : Bool
   public let writeTimeout : TimeInterval
+  public let bootstrapSQL : String?
   
   @inlinable
-  public init(url: URL, readOnly: Bool = false,
-              writeTimeout: TimeInterval = 10.0)
+  public init(url          : URL, 
+              readOnly     : Bool = false,
+              writeTimeout : TimeInterval = 10.0,
+              bootstrapSQL : String? = nil)
   {
     self.url          = url
     self.readOnly     = readOnly
     self.writeTimeout = writeTimeout
+    self.bootstrapSQL = bootstrapSQL
   }
 
   
@@ -139,6 +148,7 @@ open class SQLConnectionHandler: @unchecked Sendable {
     }
     
     sqlite3_busy_timeout(db, Int32(writeTimeout * 1000 /* ms */))
+    sqlite3_exec(db, bootstrapSQL, nil, nil, nil)
     
     return db
   }

--- a/Sources/Lighter/ConnectionHandlers/SimplePool.swift
+++ b/Sources/Lighter/ConnectionHandlers/SimplePool.swift
@@ -47,12 +47,16 @@ extension SQLConnectionHandler {
     public init(url: URL, readOnly: Bool,
                 maxAge: TimeInterval = 3.0,
                 maximumPoolSizePerConfiguration: Int = 8,
-                writeTimeout: TimeInterval)
+                writeTimeout: TimeInterval,
+                bootstrapSQL: String? = nil)
     {
       self.maxAge              = maxAge
       self.maxPerConfiguration = maximumPoolSizePerConfiguration
       
-      super.init(url: url, readOnly: readOnly, writeTimeout: writeTimeout)
+      super.init(url: url, 
+                 readOnly: readOnly, 
+                 writeTimeout: writeTimeout,
+                 bootstrapSQL: bootstrapSQL)
       
       #if os(iOS)
         lifecycle = AppLifecycleHandler(owner: self)

--- a/Sources/Lighter/Database/SQLDatabase.swift
+++ b/Sources/Lighter/Database/SQLDatabase.swift
@@ -54,8 +54,9 @@ public protocol SQLDatabase: SQLDatabaseOperations {
    * - Parameters:
    *   - url: The filesystem `URL` to a SQLite3 database file.
    *   - readOnly: Whether the database should be opened read-only.
+   *   - pragmas: SQLite pragmas to apply to each connection.
    */
-  init(url: URL, readOnly: Bool)
+  init(url: URL, readOnly: Bool, bootstrapSQL: String?)
   
   /**
    * Create or open the SQL database at the given URL.
@@ -80,7 +81,11 @@ public protocol SQLDatabase: SQLDatabaseOperations {
    *   - overwrite:       Whether the database should be deleted if it
    *                      exists already (useful during development).
    *   - databaseFileURL: The "source" database to be copied.
+   *   - pragmas:         SQLite pragmas to apply to each connection.
    */
-  static func bootstrap(at url: URL, readOnly: Bool, overwrite: Bool,
+  static func bootstrap(at url: URL, 
+                        readOnly: Bool,
+                        bootstrapSQL: String?,
+                        overwrite: Bool,
                         copying databaseFileURL: URL) throws -> Self
 }

--- a/Sources/Lighter/Database/SQLDatabaseCreation.swift
+++ b/Sources/Lighter/Database/SQLDatabaseCreation.swift
@@ -45,7 +45,9 @@ public extension SQLDatabase {
    *   - databaseFileURL: The URL of the database to be copied.
    * - Returns:           The initialized database if successful.
    */
-  static func bootstrap(at url: URL, readOnly: Bool = false,
+  static func bootstrap(at url: URL, 
+                        readOnly: Bool = false,
+                        bootstrapSQL: String?,
                         overwrite: Bool = false,
                         copying databaseFileURL: URL) throws -> Self
   {
@@ -56,7 +58,7 @@ public extension SQLDatabase {
         try fm.removeItem(at: url)
       }
       else {
-        return Self.init(url: url, readOnly: readOnly)
+        return Self.init(url: url, readOnly: readOnly, bootstrapSQL: bootstrapSQL)
       }
     }
     
@@ -66,7 +68,7 @@ public extension SQLDatabase {
     }
     
     try fm.copyItem(at: databaseFileURL, to: url)
-    return Self.init(url: url, readOnly: readOnly)
+    return Self.init(url: url, readOnly: readOnly, bootstrapSQL: bootstrapSQL)
   }
   
   /**
@@ -97,6 +99,7 @@ public extension SQLDatabase {
                         domains        : FileManager.SearchPathDomainMask
                                        = .userDomainMask,
                         readOnly       : Bool = false,
+                        bootstrapSQL   : String? = nil,
                         overwrite      : Bool = false,
                         copying databaseFileURL: URL) throws -> Self
   {
@@ -106,7 +109,10 @@ public extension SQLDatabase {
     }
     
     let url = dir.appendingPathComponent(databaseFileURL.lastPathComponent)
-    return try bootstrap(at: url, readOnly: readOnly, overwrite: overwrite,
+    return try bootstrap(at: url, 
+                         readOnly: readOnly,
+                         bootstrapSQL: bootstrapSQL,
+                         overwrite: overwrite,
                          copying: databaseFileURL)
   }
 }
@@ -139,7 +145,9 @@ public extension SQLDatabase where Self: SQLCreationStatementsHolder {
    *                exists already (useful during development).
    * - Returns:     The initialized database if successful.
    */
-  static func bootstrap(at url: URL, readOnly: Bool = false,
+  static func bootstrap(at url: URL, 
+                        readOnly: Bool = false, 
+                        bootstrapSQL: String? = nil,
                         overwrite: Bool = false) throws -> Self
   {
     let fm = FileManager.default
@@ -148,7 +156,7 @@ public extension SQLDatabase where Self: SQLCreationStatementsHolder {
         try fm.removeItem(at: url)
       }
       else {
-        return Self.init(url: url, readOnly: readOnly)
+        return Self.init(url: url, readOnly: readOnly, bootstrapSQL: bootstrapSQL)
       }
     }
     
@@ -170,7 +178,7 @@ public extension SQLDatabase where Self: SQLCreationStatementsHolder {
       throw SQLError(db)
     }
     
-    return Self(url: url, readOnly: readOnly)
+    return Self(url: url, readOnly: readOnly, bootstrapSQL: bootstrapSQL)
   }
   
   /**
@@ -206,6 +214,7 @@ public extension SQLDatabase where Self: SQLCreationStatementsHolder {
                                        = .userDomainMask,
                         filename       : String? = nil,
                         readOnly       : Bool = false,
+                        bootstrapSQL   : String?,
                         overwrite      : Bool = false) throws -> Self
   {
     guard let dir = FileManager.default.urls(for: directory, in: domains).first
@@ -216,7 +225,12 @@ public extension SQLDatabase where Self: SQLCreationStatementsHolder {
     let filename = filename ?? String(describing: self) + ".sqlite3"
     let url = dir.appendingPathComponent(filename)
     
-    return try bootstrap(at: url, readOnly: readOnly, overwrite: overwrite)
+    return try bootstrap(
+      at: url,
+      readOnly: readOnly,
+      bootstrapSQL: bootstrapSQL,
+      overwrite: overwrite
+    )
   }
 }
 #endif // canImport(Foundation)
@@ -254,14 +268,18 @@ public extension SQLDatabase where Self: SQLDatabaseAsyncOperations {
    *                      exists already (useful during development).
    *   - databaseFileURL: The "source" database to be copied.
    */
-  static func bootstrap(at url: URL, readOnly: Bool = false,
+  static func bootstrap(at url: URL, 
+                        readOnly: Bool = false,
+                        bootstrapSQL: String?,
                         overwrite: Bool = false,
                         copying databaseFileURL: URL) async throws -> Self
   {
     return try await withCheckedThrowingContinuation { continuation in
       DispatchQueue.global().async {
         do {
-          let db = try self.bootstrap(at: url, readOnly: readOnly,
+          let db = try self.bootstrap(at: url, 
+                                      readOnly: readOnly, 
+                                      bootstrapSQL: bootstrapSQL,
                                       overwrite: overwrite,
                                       copying: databaseFileURL)
           continuation.resume(returning: db)
@@ -299,14 +317,18 @@ public extension SQLDatabase where Self: SQLDatabaseAsyncOperations {
                         domains        : FileManager.SearchPathDomainMask
                                        = .userDomainMask,
                         readOnly       : Bool = false,
+                        bootstrapSQL   : String? = nil,
                         overwrite      : Bool = false,
                         copying databaseFileURL: URL) async throws -> Self
   {
     return try await withCheckedThrowingContinuation { continuation in
       DispatchQueue.global().async {
         do {
-          let db = try self.bootstrap(into: directory, domains: domains,
-                                      readOnly: readOnly, overwrite: overwrite,
+          let db = try self.bootstrap(into: directory,
+                                      domains: domains,
+                                      readOnly: readOnly,
+                                      bootstrapSQL: bootstrapSQL,
+                                      overwrite: overwrite,
                                       copying: databaseFileURL)
           continuation.resume(returning: db)
         }
@@ -345,14 +367,18 @@ public extension SQLDatabase where Self: SQLCreationStatementsHolder,
    *                exists already (useful during development).
    * - Returns:     The initialized database if successful.
    */
-  static func bootstrap(at url: URL, readOnly: Bool = false,
+  static func bootstrap(at url: URL, 
+                        readOnly: Bool = false, 
+                        bootstrapSQL: String? = nil,
                         overwrite: Bool = false)
                 async throws -> Self
   {
     return try await withCheckedThrowingContinuation { continuation in
       DispatchQueue.global().async {
         do {
-          let db = try self.bootstrap(at: url, readOnly: readOnly,
+          let db = try self.bootstrap(at: url,
+                                      readOnly: readOnly,
+                                      bootstrapSQL: bootstrapSQL,
                                       overwrite: overwrite)
           continuation.resume(returning: db)
         }
@@ -394,13 +420,17 @@ public extension SQLDatabase where Self: SQLCreationStatementsHolder,
                                        = .userDomainMask,
                         filename       : String? = nil,
                         readOnly       : Bool = false,
+                        bootstrapSQL   : String? = nil,
                         overwrite      : Bool = false) async throws -> Self
   {
     return try await withCheckedThrowingContinuation { continuation in
       DispatchQueue.global().async {
         do {
-          let db = try self.bootstrap(into: directory, domains: domains,
-                                      filename: filename, readOnly: readOnly,
+          let db = try self.bootstrap(into: directory,
+                                      domains: domains,
+                                      filename: filename,
+                                      readOnly: readOnly,
+                                      bootstrapSQL: bootstrapSQL,
                                       overwrite: overwrite)
           continuation.resume(returning: db)
         }


### PR DESCRIPTION
These pragmas are applied after opening a connection; e.g. enforcing foreign keys.

## Examples

### Using the `.bootstrap` method

```swift
struct MyApp: App {
    let db = {
        let pragmas = "PRAGMA foreign_keys = ON"

        return try! MyDatabase.bootstrap(bootstrapSQL: pragmas, overwrite: true)
        ...
    }
}
```

### Initializing the database with the `SQLConnectionHandler`
```swift
struct MyApp: App {
    let db = {
        let pragmas = "PRAGMA foreign_keys = ON"

        return MyDatabase(connectionHandler: .simplePool(url: url, readOnly: false, bootstrapSQL: pragmas))
        ...
    }
}

```

Resolves #46

NOTE: This is my first attempt at adding this functionality and it is mainly driven by my use case. I am still finding my way around the codebase; so this may or may not be optimal. Looking forward to seeing feedback to make it better and more intuitive. 